### PR TITLE
fix: adjust single post layout order to match prototype

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -4,22 +4,18 @@
       {{ .Content }}
     </div>
 
-    <p class="meta">{{ .Date.Format "January 2, 2006" }}</p>
+    {{ if .Title }}
+    <p class="meta post-title">
+      {{ .Title }}{{ with .Params.bookmark_of }} (via <a href="{{ . }}" rel="noopener" target="_blank">{{ . | replaceRE "^https?://(www\\.)?" "" | replaceRE "/.*$" "" | title }}</a>){{ end }}
+    </p>
+    {{ end }}
 
-    {{ if or .Title .Params.categories .Params.bookmark_of }}
     <div class="meta badges">
-      {{ if .Title }}
-      <p class="post-title-meta">{{ .Title }}</p>
-      {{ end }}
-
       {{ range .Params.categories }}
         {{ partial "category-badge.html" . }}
       {{ end }}
-
-      {{ with .Params.bookmark_of }}
-      <a class="bookmark-link" href="{{ . }}" rel="noopener" target="_blank">Original ↗</a>
-      {{ end }}
     </div>
-    {{ end }}
+
+    <p class="meta post-date">{{ .Date.Format "January 2, 2006" }}</p>
   </article>
 {{ end }}


### PR DESCRIPTION
Updated layout order:
1. Content (blockquote, images, etc)
2. Title with bookmark source formatted as "Title (via Source)"
3. Category badges
4. Date moved to bottom near categories

Bookmark source link now extracts domain name from URL.