### PR TITLE
feat: replace search input with magnifying glass icon

### DIFF
--- a/layouts/partials/search.html
+++ b/layouts/partials/search.html
@@ -1,5 +1,6 @@
-<form class="search-form">
-  <label for="saunter-search" class="sr-only">Search</label>
-  <input id="saunter-search" class="field" type="search" placeholder="Search…" />
-  <div id="list_results"></div>
-</form>
+<a href="{{ "/search/" | relURL }}" class="icon-button" aria-label="Search">
+  <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+    <circle cx="11" cy="11" r="8"></circle>
+    <path d="m21 21-4.35-4.35"></path>
+  </svg>
+</a>


### PR DESCRIPTION
Replace search form with a simple magnifying glass icon that links to /search/ page. Matches the design pattern of other icon buttons in the navigation.