### PR TITLE
Build watch page feature

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,7 +1,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="generator" content="Saunter 0.1.43">
+  <meta name="generator" content="Saunter 0.1.46">
   {{ $cacheBust := or .Site.Params.theme_seconds (now.Unix) }}
   <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }} · {{ .Site.Title }}{{ end }}</title>
 

--- a/layouts/partials/watching-grid.html
+++ b/layouts/partials/watching-grid.html
@@ -51,25 +51,6 @@
   {{/* Combine all detection methods (union removes duplicates) */}}
   {{ $posts = union $posts $prefixPosts }}
 
-  {{/* DEBUG: Show what each method found */}}
-  <div style="background: #e3f2fd; padding: 10px; margin: 10px 0; border-left: 4px solid #2196f3;">
-    <strong>🔍 Detection Debug:</strong><br>
-    Category posts: {{ len $categoryPosts }}<br>
-    Tag posts: {{ len $tagPosts }}<br>
-    Prefix posts: {{ len $prefixPosts }}<br>
-    <strong>Total unique posts: {{ len $posts }}</strong><br>
-    {{ if gt (len $posts) 0 }}
-      <details>
-        <summary>All detected posts:</summary>
-        <ul style="margin: 5px 0; padding-left: 20px;">
-        {{ range $posts }}
-          <li><code>{{ .RelPermalink }}</code> - {{ .Title | default .Summary | truncate 50 }}</li>
-        {{ end }}
-        </ul>
-      </details>
-    {{ end }}
-  </div>
-
   {{/* If no posts found, fall back to data files */}}
   {{ if eq (len $posts) 0 }}
     {{/* Try data/watched.enriched.json first */}}
@@ -122,6 +103,19 @@
       {{ $posterUrl = .Params.image }}
     {{ else if .Params.featured_image }}
       {{ $posterUrl = .Params.featured_image }}
+    {{ end }}
+
+    {{/* If no frontmatter image, try to extract from content */}}
+    {{ if not $posterUrl }}
+      {{ $imgMatches := findRE `<img[^>]+src="([^"]+)"` .Content 1 }}
+      {{ if $imgMatches }}
+        {{ $imgTag := index $imgMatches 0 }}
+        {{ $srcMatches := findRE `src="([^"]+)"` $imgTag 1 }}
+        {{ if $srcMatches }}
+          {{ $src := index $srcMatches 0 }}
+          {{ $posterUrl = replaceRE `src="([^"]+)"` "$1" $src }}
+        {{ end }}
+      {{ end }}
     {{ end }}
 
     <article class="watch-card">

--- a/layouts/watching/single.html
+++ b/layouts/watching/single.html
@@ -6,10 +6,29 @@
   {{ $featuredImage = .Params.featured_image }}
   {{ else if .Params.image }}
   {{ $featuredImage = .Params.image }}
+  {{ else if .Params.photo }}
+  {{ $featuredImage = .Params.photo }}
+  {{ else if .Params.photos }}
+  {{ if gt (len .Params.photos) 0 }}
+  {{ $featuredImage = index .Params.photos 0 }}
+  {{ end }}
   {{ else }}
   {{ with .Params.images }}
   {{ if gt (len .) 0 }}
   {{ $featuredImage = index . 0 }}
+  {{ end }}
+  {{ end }}
+  {{ end }}
+
+  {{/* If no frontmatter image, try to extract from content */}}
+  {{ if not $featuredImage }}
+  {{ $imgMatches := findRE `<img[^>]+src="([^"]+)"` .Content 1 }}
+  {{ if $imgMatches }}
+  {{ $imgTag := index $imgMatches 0 }}
+  {{ $srcMatches := findRE `src="([^"]+)"` $imgTag 1 }}
+  {{ if $srcMatches }}
+  {{ $src := index $srcMatches 0 }}
+  {{ $featuredImage = replaceRE `src="([^"]+)"` "$1" $src }}
   {{ end }}
   {{ end }}
   {{ end }}

--- a/plugin.json
+++ b/plugin.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.1.45",
+	"version": "0.1.46",
 	"title": "Saunter theme",
 	"description": "An editorial-style theme for Micro.blog with dark mode support, category badges, and newsletter integration."
 }


### PR DESCRIPTION
- Add image extraction from post content HTML for both list and single pages
- Check for images in content if not found in frontmatter (photos, images, photo, image, featured_image)
- Remove visible debug output block from watching page
- Bump version to 0.1.46

This fixes the issue where watching posts with embedded images weren't showing thumbnails/posters because the code only looked in frontmatter fields.