### PR TITLE
[feat] Remove URL manipulation for book covers (refs rocksoup/microin…

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,7 +1,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="generator" content="Saunter 0.1.50">
+  <meta name="generator" content="Saunter 0.1.51">
   {{ $cacheBust := or .Site.Params.theme_seconds (now.Unix) }}
   <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }} · {{ .Site.Title }}{{ end }}</title>
 

--- a/layouts/reading/single.html
+++ b/layouts/reading/single.html
@@ -20,7 +20,7 @@
       {{ range $currentlyReading }}
       <a href="https://micro.blog/books/{{ .isbn }}" class="book-card" target="_blank" rel="noopener">
         {{ if .cover_url }}
-        <img src="{{ .cover_url | replaceRE "/300x/" "/600x/" | replaceRE "%26zoom%3D[15]" "%26zoom%3D0" }}"
+        <img src="{{ .cover_url }}"
           alt="Cover of {{ .title }}" class="book-cover" loading="lazy">
         {{ else }}
         <div class="book-cover-placeholder">No Cover</div>
@@ -57,7 +57,7 @@
       {{ range $wantToRead }}
       <a href="https://micro.blog/books/{{ .isbn }}" class="book-card" target="_blank" rel="noopener">
         {{ if .cover_url }}
-        <img src="{{ .cover_url | replaceRE "/300x/" "/600x/" | replaceRE "%26zoom%3D[15]" "%26zoom%3D0" }}"
+        <img src="{{ .cover_url }}"
           alt="Cover of {{ .title }}" class="book-cover" loading="lazy">
         {{ else }}
         <div class="book-cover-placeholder">No Cover</div>
@@ -94,7 +94,7 @@
       {{ range $finishedReading }}
       <a href="https://micro.blog/books/{{ .isbn }}" class="book-card" target="_blank" rel="noopener">
         {{ if .cover_url }}
-        <img src="{{ .cover_url | replaceRE "/300x/" "/600x/" | replaceRE "%26zoom%3D[15]" "%26zoom%3D0" }}"
+        <img src="{{ .cover_url }}"
           alt="Cover of {{ .title }}" class="book-cover" loading="lazy">
         {{ else }}
         <div class="book-cover-placeholder">No Cover</div>

--- a/plugin.json
+++ b/plugin.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.1.50",
+	"version": "0.1.51",
 	"title": "Saunter theme",
 	"description": "An editorial-style theme for Micro.blog with dark mode support, category badges, and newsletter integration."
 }


### PR DESCRIPTION
…tegrations#60)

- Remove replaceRE filters from reading template (3 places)
- Book cover URLs now come pre-optimized from microintegrations workflow
- Bump version to 0.1.51 for Micro.blog to pull updates

Related to microintegrations fix that upgrades Google Books URLs to zoom=0 for 16x better image quality (2076×2976px vs 128×193px).

🤖 Generated with Claude Code (https://claude.com/claude-code)